### PR TITLE
Implement hardcoded support for default namespace

### DIFF
--- a/internal/generator/generator_attributes.go
+++ b/internal/generator/generator_attributes.go
@@ -12,11 +12,13 @@ type AttributeGenerator struct {
 	PlanModifierType    string
 	PlanModifierPackage string
 
-	Required           bool
-	Description        string
-	Computed           bool
-	Sensitive          bool
-	Immutable          bool
+	Required    bool
+	Description string
+	Computed    bool
+	Sensitive   bool
+	Immutable   bool
+	// TODO implement generic default support
+	DefaultNamespace   bool
 	GenAIValidatorType string
 
 	NestedAttributes AttributesGenerator

--- a/internal/generator/generator_resource.go
+++ b/internal/generator/generator_resource.go
@@ -69,6 +69,10 @@ func (g *ResourceGenerator) GenerateSchemaFunctionCode() string {
 		g.Schema.Imports = imports
 	}
 
+	if metadataNamespaceDefault(g.Schema.Attributes, "") {
+		g.Schema.DefaultNamespace = true
+	}
+
 	return renderTemplate(schemaFunctionTemplate, g)
 }
 

--- a/internal/generator/generator_schema.go
+++ b/internal/generator/generator_schema.go
@@ -11,7 +11,9 @@ type SchemaGenerator struct {
 	Name        string
 	Description string
 	Attributes  AttributesGenerator
-	Imports     []string
+	// TODO support generic defaults
+	DefaultNamespace bool
+	Imports          []string
 }
 
 func (g SchemaGenerator) String() string {
@@ -32,4 +34,20 @@ func getPlanModifierImports(a AttributesGenerator) []string {
 
 	// FIXME: this will need to dedupe
 	return imports
+}
+
+// Recursively marks attributes that are metadata.namespace as a quick and dirty
+// fix for having namespace support a default value of "default".
+// Returns true if it has found any matching attribute in the resource.
+// TODO handle lists?
+func metadataNamespaceDefault(a AttributesGenerator, parent string) bool {
+	for i := range a {
+		if a[i].Name == "namespace" && parent == "metadata" {
+			a[i].DefaultNamespace = true
+			return true
+		} else if len(a[i].NestedAttributes) > 0 {
+			return metadataNamespaceDefault(a[i].NestedAttributes, a[i].Name)
+		}
+	}
+	return false
 }

--- a/internal/generator/templates/attribute.tpl
+++ b/internal/generator/templates/attribute.tpl
@@ -14,6 +14,11 @@ Optional: true,
 Computed: true,
 {{- end }}
 
+{{/* TODO support generic defaults */}}
+{{- if .DefaultNamespace }}
+Default: stringdefault.StaticString("default"),
+{{- end }}
+
 {{- if .Sensitive }}
 Sensitive: true,
 {{- end }}

--- a/internal/generator/templates/resource_schema.go.tpl
+++ b/internal/generator/templates/resource_schema.go.tpl
@@ -14,6 +14,9 @@ import (
   {{- if .ResourceConfig.Generate.GenAIValidation }}
   "github.com/hashicorp/terraform-plugin-framework/schema/validator"
   {{- end }}
+  {{- if .Schema.DefaultNamespace }}
+  "github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+  {{- end }}
 )
 
 func (r *{{ .ResourceConfig.Kind }}) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {


### PR DESCRIPTION
Codegen-ing default value support is not yet solved. The `metadata.namespace` attribute is present in nearly every resource and causes a permadiff because the new framework implementation does not perform "tail-calling" read after create (which would pull the "default" namespace from the backend). Tail-calling read like that causes lots of subtle bugs like this, even though its extremely convenient at times and present in nearly all sdkv2 based providers, its not [prescribed with framework](https://github.com/hashicorp/terraform-plugin-framework/issues/277)

This PR slaps a bandaid on `metadata.namespace`